### PR TITLE
advanced interface (and some cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/
 
 .ruby-version
 .rbenv-gemsets
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ coverage.info
 coverage/
 doc/
 pkg/
+
+.ruby-version
+.rbenv-gemsets

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,6 @@
 = kuler Changelog
 
-=== 0.2.0 / 2013-02-10
+=== 0.2.0-pre / 2013-02-10
 
 * 1 major enhancement
   * kuler now provides an interface to actually fetch multiple themes.

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,6 @@
 = kuler Changelog
 
-=== 0.2.0-pre / 2013-02-10
+=== 0.2.0.pre / 2013-02-10
 
 * 1 major enhancement
   * kuler now provides an interface to actually fetch multiple themes.

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,10 @@
 = kuler Changelog
 
+=== 0.2.0 / 2013-02-10
+
+* 1 major enhancement
+  * kuler now provides an interface to actually fetch multiple themes.
+
 === 0.1.0 / 2010-03-29
 
 * 1 major enhancement

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -6,6 +6,7 @@ Rakefile
 lib/kuler.rb
 lib/kuler/swatch.rb
 lib/kuler/theme.rb
+test/fixtures/mult_rating_results.xml
 test/fixtures/single_random_result.xml
 test/test_kuler.rb
 test/test_kuler_swatch.rb

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,39 +11,41 @@ share color themes. This is a Ruby library to access the Kuler service.
 To use Kuler, you'll need an API key, which you can obtain from Adobe at
 http://kuler.adobe.com/api
 
-== FEATURES/PROBLEMS
-
-* retrieve color themes from Kuler:
-  * most recent themes
-  * most popular
-  * highest rated
-  * random
-
 == SYNOPSIS
 
-Set up a new Kuler instance with your API key:
+*First*, set up a new Kuler instance with your API key. Either provide it directly
+as paramater:
 
     kuler = Kuler.new('your api key')
 
-... or set ENV['KULER_API_KEY'] and leave the parameter:
+or set <code>ENV['KULER_API_KEY']</code> and leave the parameter:
 
     kuler = Kuler.new
 
-... then, grab a random color theme:
+To *interact* with the Kuler API, you can fetch a random color theme and inspect
+it like so:
 
     theme = kuler.fetch_random_theme
-
-... and inspect the color theme:
-
     theme.hex_codes
     #=> [ "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ff00ff" ]
 
-... or fetch a bunch of themes:
+To *refine* the search, use the Kuler#fetch_themes method:
 
     themes = kuler.fetch_themes(:type => :rating, :limit => 3)
-    #=> [ <#Kuler::Theme ...>, <#Kuler::Theme ...>, <#Kuler::Theme ...> ]
+    #=> [ #<Kuler::Theme ...>, #<Kuler::Theme ...>, #<Kuler::Theme ...> ]
 
-For more, check out the rdoc.
+== FEATURES/PROBLEMS
+
+Retrieve color themes from Kuler:
+
+most recent themes::  <code>kuler.fetch_themes(:type => :recent)</code>
+most popular::        <code>kuler.fetch_themes(:type => :popular)</code>
+highest rated::       <code>kuler.fetch_themes(:type => :rated)</code>
+random::              <code>kuler.fetch_themes(:type => :random)</code>
+limit the results::   <code>kuler.fetch_themes(:limit => 25)</code>
+offset the results::  <code>kuler.fetch_themes(:offset => 3)</code>
+
+More details on limitations, return values etc. are available in the RDoc.
 
 == REQUIREMENTS
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -23,12 +23,11 @@ http://kuler.adobe.com/api
 
 Set up a new Kuler instance with your API key:
 
-    kuler = Kuler.new( 'your api key' )
+    kuler = Kuler.new('your api key')
 
-    # ... or ...
+... or set ENV['KULER_API_KEY'] and leave the parameter:
 
     kuler = Kuler.new
-    kuler.api_key = 'your api key'
 
 ... then, grab a random color theme:
 
@@ -37,7 +36,12 @@ Set up a new Kuler instance with your API key:
 ... and inspect the color theme:
 
     theme.hex_codes
-    => [ "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ff00ff" ]
+    #=> [ "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ff00ff" ]
+
+... or fetch a bunch of themes:
+
+    themes = kuler.fetch_themes(:type => :rating, :limit => 3)
+    #=> [ <#Kuler::Theme ...>, <#Kuler::Theme ...>, <#Kuler::Theme ...> ]
 
 For more, check out the rdoc.
 

--- a/lib/kuler.rb
+++ b/lib/kuler.rb
@@ -30,21 +30,25 @@ class Kuler
   ###           Defaults to 20.
   def build_url(options = {})
     o = {
-      :type  => :recent,
-      :limit => 20
+      :type   => :recent,
+      :limit  => 20,
+      :offset => 0
     }.merge(options)
 
     unless [ :recent, :popular, :rating, :random ].include? o[:type]
       raise ArgumentError, "unknown feed type '#{o[:type]}'. Valid options are recent, popular, rating, or random"
     end
 
-    o[:limit] = [1,   (o[:limit] || 1).to_i  ].max
-    o[:limit] = [100, (o[:limit] || 100).to_i].min
+    o[:limit]   = [(o[:limit] || 1).to_i, 1].max
+    o[:limit]   = [100, (o[:limit] || 100).to_i].min
+    o[:offset]  = [(o[:offset] || 0).to_i, 0 ].max
 
+    # tranlate english keys to Adobe API keyword english
     options = {
       :key          => self.api_key,
       :itemsPerPage => o[:limit],
       :listType     => o[:type],
+      :startIndex   => o[:offset]
     }
 
     get_args = options.

--- a/lib/kuler.rb
+++ b/lib/kuler.rb
@@ -71,10 +71,9 @@ class Kuler
   ### Kuler.build_url. Return an array of Kuler::Theme items.
   def fetch_themes(options={})
     url = build_url options
-    themes = Nokogiri::XML(open(url)).xpath('//item').map do |item|
-      Kuler::Theme.new item.at('//kuler:themeItem')
+    themes = Nokogiri::XML(open(url)).search('//item').map do |item|
+      Kuler::Theme.new item.at('./kuler:themeItem')
     end
-
     themes
   end
 end

--- a/lib/kuler.rb
+++ b/lib/kuler.rb
@@ -6,7 +6,7 @@ require 'kuler/theme'
 
 class Kuler
   # Kuler Version (SemVer)
-  VERSION = '0.2.0'
+  VERSION = '0.2.0-pre'
 
   # API URL template
   API_URL = "https://kuler-api.adobe.com/rss/get.cfm?%s"

--- a/lib/kuler.rb
+++ b/lib/kuler.rb
@@ -5,43 +5,46 @@ require 'kuler/swatch'
 require 'kuler/theme'
 
 class Kuler
-  VERSION = '0.1.0' # Kuler Version
+  # Kuler Version (SemVer)
+  VERSION = '0.2.0'
+
+  # API URL template
   API_URL = "https://kuler-api.adobe.com/rss/get.cfm?%s"
 
   ### the key required to access the kuler API
   attr_reader :api_key
 
-  ### Create a new Kuler object. Accepts a single argument, the
-  ### +api_key+.
-  def initialize( api_key )
-    @api_key = api_key
+  ### Create a new Kuler object. Accepts a single argument, the +api_key+.
+  ### If none provided, the KULER_API_KEY environment variable is used.
+  def initialize(api_key=nil)
+    @api_key = api_key || ENV['KULER_API_KEY'] || raise(ArgumentError, 'no API key found')
   end
 
   ### Build the appropriate URL for a request to the Kuler API.
   ###
-  ### Parameters:
-  ### +type+::  the type of API call to make. Options are +recent+,
-  ###           +popular+, +rating+, or +random+.
+  ### Options:
+  ### +type+::  the type of API call to make. Options are +recent+ (default
+  ###           if not given), +popular+, +rating+, or +random+.
   ### +limit+:: the number of themes to return. Valid range is 1 to 100.
   ###           Numbers outside this range will be capped to those limits.
-  def build_url(opts = {})
-    # default options
-    opts = {
+  ###           Defaults to 20.
+  def build_url(options = {})
+    o = {
       :type  => :recent,
       :limit => 20
-    }.merge(opts)
+    }.merge(options)
 
-    unless [ :recent, :popular, :rating, :random ].include? opts[:type]
-      raise ArgumentError, "unknown feed type '#{opts[:type]}'. Valid options are recent, popular, rating, or random"
+    unless [ :recent, :popular, :rating, :random ].include? o[:type]
+      raise ArgumentError, "unknown feed type '#{o[:type]}'. Valid options are recent, popular, rating, or random"
     end
 
-    opts[:limit] = [1,   (opts[:limit] || 1).to_i  ].max
-    opts[:limit] = [100, (opts[:limit] || 100).to_i].min
+    o[:limit] = [1,   (o[:limit] || 1).to_i  ].max
+    o[:limit] = [100, (o[:limit] || 100).to_i].min
 
     options = {
       :key          => self.api_key,
-      :itemsPerPage => opts[:limit],
-      :listType     => opts[:type],
+      :itemsPerPage => o[:limit],
+      :listType     => o[:type],
     }
 
     get_args = options.
@@ -53,10 +56,21 @@ class Kuler
     return API_URL % get_args
   end
 
-  ### fetch a single random color theme
+  ### Fetch a single random color theme. Returns a single Kuler::Theme
   def fetch_random_theme
-    url = build_url( :type => :random, :limit => 1 )
-    xml = Nokogiri::XML( open(url) ).at( "//kuler:themeItem" )
-    return Kuler::Theme.new( xml )
+    fetch_themes(:type => :random, :limit => 1).first
+  end
+
+  ### Searches and fetches a set of themes filtered by the given arguments.
+  ###
+  ### Valid +options+ and their default values are defined through
+  ### Kuler.build_url. Return an array of Kuler::Theme items.
+  def fetch_themes(options={})
+    url = build_url options
+    themes = Nokogiri::XML(open(url)).xpath('//item').map do |item|
+      Kuler::Theme.new item.at('//kuler:themeItem')
+    end
+
+    themes
   end
 end

--- a/lib/kuler.rb
+++ b/lib/kuler.rb
@@ -6,7 +6,7 @@ require 'kuler/theme'
 
 class Kuler
   # Kuler Version (SemVer)
-  VERSION = '0.2.0-pre'
+  VERSION = '0.2.0.pre'
 
   # API URL template
   API_URL = "https://kuler-api.adobe.com/rss/get.cfm?%s"

--- a/lib/kuler/swatch.rb
+++ b/lib/kuler/swatch.rb
@@ -5,11 +5,9 @@ class Kuler
     attr_accessor :hex_code
 
     ### create a new Kuler::Swatch from a Nokogiri::XML::Element
-    def initialize( input )
-      hex = input.at( "./kuler:swatchHexColor" ).text
+    def initialize(input)
+      hex = input.at('./kuler:swatchHexColor').text
       @hex_code = "##{hex.downcase}"
     end
-
   end
-
 end # class Kuler

--- a/lib/kuler/theme.rb
+++ b/lib/kuler/theme.rb
@@ -1,6 +1,5 @@
 class Kuler
   class Theme
-
     ### the Kuler ID for the theme
     attr_reader :theme_id
 
@@ -23,18 +22,15 @@ class Kuler
     ### this theme
     attr_reader :swatches
 
-
     ### create a new Kuler::Theme from a Nokogiri::XML::Element
     def initialize( input )
-      @theme_id    = input.at('//kuler:themeID'    ).text.to_i
-      @title       = input.at('//kuler:themeTitle' ).text
-      @tags        = input.at('//kuler:themeTags'  ).text.gsub(/\s/, '').split(',')
-      @rating      = input.at('//kuler:themeRating').text.to_i
-
-      @author_name = input.at('//kuler:themeAuthor/kuler:authorLabel').text
-      @author_id   = input.at('//kuler:themeAuthor/kuler:authorID'   ).text.to_i
-
-      @swatches = input.search('//kuler:swatch').map {|nodes| Kuler::Swatch.new nodes }
+      @theme_id     = input.at('./kuler:themeID'    ).text.to_i
+      @title        = input.at('./kuler:themeTitle' ).text
+      @tags         = input.at('./kuler:themeTags'  ).text.gsub(/\s/, '').split(',')
+      @rating       = input.at('./kuler:themeRating').text.to_i
+      @author_name  = input.at('./kuler:themeAuthor/kuler:authorLabel').text
+      @author_id    = input.at('./kuler:themeAuthor/kuler:authorID'   ).text.to_i
+      @swatches     = input.search('.//kuler:swatch').map {|n| Kuler::Swatch.new n }
     end
 
     ### returns an array of hex values of the swatches in this theme

--- a/lib/kuler/theme.rb
+++ b/lib/kuler/theme.rb
@@ -26,23 +26,20 @@ class Kuler
 
     ### create a new Kuler::Theme from a Nokogiri::XML::Element
     def initialize( input )
-      @theme_id    = input.at( "//kuler:themeID"     ).text.to_i
-      @title       = input.at( "//kuler:themeTitle"  ).text
-      @tags        = input.at( "//kuler:themeTags"   ).text.gsub(/\s/, '').split(',')
-      @rating      = input.at( "//kuler:themeRating" ).text.to_i
+      @theme_id    = input.at('//kuler:themeID'    ).text.to_i
+      @title       = input.at('//kuler:themeTitle' ).text
+      @tags        = input.at('//kuler:themeTags'  ).text.gsub(/\s/, '').split(',')
+      @rating      = input.at('//kuler:themeRating').text.to_i
 
-      @author_name = input.at( "//kuler:themeAuthor/kuler:authorLabel" ).text
-      @author_id   = input.at( "//kuler:themeAuthor/kuler:authorID"    ).text.to_i
+      @author_name = input.at('//kuler:themeAuthor/kuler:authorLabel').text
+      @author_id   = input.at('//kuler:themeAuthor/kuler:authorID'   ).text.to_i
 
-      @swatches = input.search( "//kuler:swatch" ).map {|nodes| Kuler::Swatch.new nodes }
+      @swatches = input.search('//kuler:swatch').map {|nodes| Kuler::Swatch.new nodes }
     end
-
 
     ### returns an array of hex values of the swatches in this theme
     def hex_codes
-      self.swatches.map {|s| s.hex_code }
+      @hex_codes ||= self.swatches.map {|s| s.hex_code }
     end
-
   end
-
 end # class Kuler

--- a/test/fixtures/mult_rating_results.xml
+++ b/test/fixtures/mult_rating_results.xml
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:kuler="http://kuler.adobe.com/kuler/API/rss/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:rss="http://blogs.law.harvard.edu/tech/rss" version="2.0">
+  <channel>
+    <title>kuler highest rated themes</title>
+    <link>http://kuler.adobe.com/</link>
+    <description>highest-rated themes on kuler (1 to 5 of 805290)</description>
+    <language>en-us</language>
+    <pubDate>Sun, 10 Feb 2013 06:15:38 PST</pubDate>
+    <lastBuildDate>Sun, 10 Feb 2013 06:15:38 PST</lastBuildDate>
+    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    <generator>Kuler Services</generator>
+    <managingEditor>kulerfeedback@adobe.com</managingEditor>
+    <webMaster>kulerfeedback@adobe.com</webMaster>
+    <recordCount>805290</recordCount>
+    <startIndex>0</startIndex>
+    <itemsPerPage>5</itemsPerPage>
+    <item>
+      <title>Theme Title: Vintage Ralph Lauren</title>
+      <link>http://kuler.adobe.com/index.cfm#themeID/2216979</link>
+      <guid>http://kuler.adobe.com/index.cfm#themeID/2216979</guid>
+      <enclosure xmlns="http://www.solitude.dk/syndication/enclosures/">
+        <title>Vintage Ralph Lauren</title>
+        <link type="image/png" length="1">
+          <url>http://kuler-api.adobe.com/kuler/themeImages/theme_2216979.png</url>
+        </link>
+      </enclosure>
+      <description>
+        &lt;img src="http://kuler-api.adobe.com/kuler/themeImages/theme_2216979.png" /&gt;&lt;br /&gt;
+        Artist: dianesteinberg&lt;br /&gt; ThemeID: 2216979&lt;br /&gt; Posted: 01/09/2013&lt;br /&gt;
+        Tags: blue, classic, faded, gray, ralph lauren, vintage&lt;br /&gt;
+        Hex: 703030, 2F343B, 7E827A, E3CDA4, C77966
+      </description>
+      <kuler:themeItem>
+        <kuler:themeID>2216979</kuler:themeID>
+        <kuler:themeTitle>Vintage Ralph Lauren</kuler:themeTitle>
+        <kuler:themeImage>http://kuler-api.adobe.com/kuler/themeImages/theme_2216979.png</kuler:themeImage>
+        <kuler:themeAuthor>
+          <kuler:authorID>279320</kuler:authorID>
+          <kuler:authorLabel>dianesteinberg</kuler:authorLabel>
+        </kuler:themeAuthor>
+        <kuler:themeTags>blue, classic, faded, gray, ralph lauren, vintage</kuler:themeTags>
+        <kuler:themeRating>4</kuler:themeRating>
+        <kuler:themeDownloadCount>1379</kuler:themeDownloadCount>
+        <kuler:themeCreatedAt>20130109</kuler:themeCreatedAt>
+        <kuler:themeEditedAt>20130109</kuler:themeEditedAt>
+        <kuler:themeSwatches>
+          <kuler:swatch>
+            <kuler:swatchHexColor>703030</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.44</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.190123</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.190123</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>0</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>2F343B</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.185103</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.203562</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.23</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>1</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>7E827A</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.49453</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.51</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.478519</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>2</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>E3CDA4</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.89</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.802294</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.643083</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>3</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>C77966</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.78</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.475812</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.399051</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>4</kuler:swatchIndex>
+          </kuler:swatch>
+        </kuler:themeSwatches>
+      </kuler:themeItem>
+      <pubDate>Sun, 10 Feb 2013 06:15:38 PST</pubDate>
+    </item>
+    <item>
+      <title>Theme Title: Appalachian Spring</title>
+      <link>http://kuler.adobe.com/index.cfm#themeID/1974489</link>
+      <guid>http://kuler.adobe.com/index.cfm#themeID/1974489</guid>
+      <enclosure xmlns="http://www.solitude.dk/syndication/enclosures/">
+        <title>Appalachian Spring</title>
+        <link type="image/png" length="1">
+          <url>http://kuler-api.adobe.com/kuler/themeImages/theme_1974489.png</url>
+        </link>
+      </enclosure>
+      <description>
+        &lt;img src="http://kuler-api.adobe.com/kuler/themeImages/theme_1974489.png" /&gt;&lt;br /&gt;
+        Artist: syork&lt;br /&gt;ThemeID: 1974489&lt;br /&gt;Posted: 07/02/2012&lt;br /&gt;
+        Hex: C24704, D9CC3C, FFEB79, A0E0A9, 00ADA7
+      </description>
+      <kuler:themeItem>
+        <kuler:themeID>1974489</kuler:themeID>
+        <kuler:themeTitle>Appalachian Spring</kuler:themeTitle>
+        <kuler:themeImage>http://kuler-api.adobe.com/kuler/themeImages/theme_1974489.png</kuler:themeImage>
+        <kuler:themeAuthor>
+          <kuler:authorID>254539</kuler:authorID>
+          <kuler:authorLabel>syork</kuler:authorLabel>
+        </kuler:themeAuthor>
+        <kuler:themeTags/>
+        <kuler:themeRating>4</kuler:themeRating>
+        <kuler:themeDownloadCount>1524</kuler:themeDownloadCount>
+        <kuler:themeCreatedAt>20120702</kuler:themeCreatedAt>
+        <kuler:themeEditedAt>20120702</kuler:themeEditedAt>
+        <kuler:themeSwatches>
+          <kuler:swatch>
+            <kuler:swatchHexColor>C24704</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.76</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.277853</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.014975</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>0</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>D9CC3C</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.85</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.800403</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.235865</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>1</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>FFEB79</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>1.0</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.92038</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.474329</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>2</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>A0E0A9</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.628007</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.88</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.663992</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>3</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>00ADA7</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.0</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.68</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.653181</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>4</kuler:swatchIndex>
+          </kuler:swatch>
+        </kuler:themeSwatches>
+      </kuler:themeItem>
+      <pubDate>Sun, 10 Feb 2013 06:15:38 PST</pubDate>
+    </item>
+    <item>
+      <title>Theme Title: CS04</title>
+      <link>http://kuler.adobe.com/index.cfm#themeID/1994456</link>
+      <guid>http://kuler.adobe.com/index.cfm#themeID/1994456</guid>
+      <enclosure xmlns="http://www.solitude.dk/syndication/enclosures/">
+        <title>CS04</title>
+        <link type="image/png" length="1">
+          <url>http://kuler-api.adobe.com/kuler/themeImages/theme_1994456.png</url>
+        </link>
+      </enclosure>
+      <description>
+        &lt;img src="http://kuler-api.adobe.com/kuler/themeImages/theme_1994456.png" /&gt;&lt;br /&gt;
+        Artist: b_wiebe&lt;br /&gt;ThemeID: 1994456&lt;br /&gt;Posted: 07/19/2012&lt;br /&gt;
+        Tags: appnic&lt;br /&gt;
+        Hex: F6F792, 333745, 77C4D3, DAEDE2, EA2E49
+      </description>
+      <kuler:themeItem>
+        <kuler:themeID>1994456</kuler:themeID>
+        <kuler:themeTitle>CS04</kuler:themeTitle>
+        <kuler:themeImage>http://kuler-api.adobe.com/kuler/themeImages/theme_1994456.png</kuler:themeImage>
+        <kuler:themeAuthor>
+          <kuler:authorID>16640</kuler:authorID>
+          <kuler:authorLabel>b_wiebe</kuler:authorLabel>
+        </kuler:themeAuthor>
+        <kuler:themeTags>appnic</kuler:themeTags>
+        <kuler:themeRating>4</kuler:themeRating>
+        <kuler:themeDownloadCount>1843</kuler:themeDownloadCount>
+        <kuler:themeCreatedAt>20120719</kuler:themeCreatedAt>
+        <kuler:themeEditedAt>20120719</kuler:themeEditedAt>
+        <kuler:themeSwatches>
+          <kuler:swatch>
+            <kuler:swatchHexColor>F6F792</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.964706</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.968627</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.572549</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>0</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>333745</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.199289</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.215578</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.27</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>1</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>77C4D3</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.465992</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.768536</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.827451</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>2</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>DAEDE2</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.854902</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.929412</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.886275</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>3</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>EA2E49</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.917647</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.179088</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.287378</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>4</kuler:swatchIndex>
+          </kuler:swatch>
+        </kuler:themeSwatches>
+      </kuler:themeItem>
+      <pubDate>Sun, 10 Feb 2013 06:15:38 PST</pubDate>
+    </item>
+    <item>
+      <title>Theme Title: Home Decor 1</title>
+      <link>http://kuler.adobe.com/index.cfm#themeID/2247332</link>
+      <guid>http://kuler.adobe.com/index.cfm#themeID/2247332</guid>
+      <enclosure xmlns="http://www.solitude.dk/syndication/enclosures/">
+        <title>Home Decor 1</title>
+        <link type="image/png" length="1">
+          <url>http://kuler-api.adobe.com/kuler/themeImages/theme_2247332.png</url>
+        </link>
+      </enclosure>
+      <description>
+        &lt;img src="http://kuler-api.adobe.com/kuler/themeImages/theme_2247332.png" /&gt;&lt;br /&gt;
+        Artist: chris24gonzy&lt;br /&gt;ThemeID: 2247332&lt;br /&gt;Posted: 01/28/2013&lt;br /&gt;
+        Tags: bright, calm, grey, house, light, living, offwhite, orange, outside, peaceful, peach, room, sun, sunny, vibrance, warm, white&lt;br /&gt;
+        Hex: 736C48, F2E3B3, F2A950, D98032, D95D30
+      </description>
+      <kuler:themeItem>
+        <kuler:themeID>2247332</kuler:themeID>
+        <kuler:themeTitle>Home Decor 1</kuler:themeTitle>
+        <kuler:themeImage>http://kuler-api.adobe.com/kuler/themeImages/theme_2247332.png</kuler:themeImage>
+        <kuler:themeAuthor>
+          <kuler:authorID>870986</kuler:authorID>
+          <kuler:authorLabel>chris24gonzy</kuler:authorLabel>
+        </kuler:themeAuthor>
+        <kuler:themeTags>bright, calm, grey, house, light, living, offwhite, orange, outside, peaceful, peach, room, sun, sunny, vibrance, warm, white</kuler:themeTags>
+        <kuler:themeRating>4</kuler:themeRating>
+        <kuler:themeDownloadCount>68</kuler:themeDownloadCount>
+        <kuler:themeCreatedAt>20130128</kuler:themeCreatedAt>
+        <kuler:themeEditedAt>20130129</kuler:themeEditedAt>
+        <kuler:themeSwatches>
+          <kuler:swatch>
+            <kuler:swatchHexColor>736C48</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.45098</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.423529</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.282353</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>0</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>F2E3B3</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.94902</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.890196</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.701961</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>1</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>F2A950</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.94902</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.662745</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.313725</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>2</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>D98032</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.85098</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.501961</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.196078</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>3</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>D95D30</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.85098</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.364706</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.188235</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>4</kuler:swatchIndex>
+          </kuler:swatch>
+        </kuler:themeSwatches>
+      </kuler:themeItem>
+      <pubDate>Sun, 10 Feb 2013 06:15:38 PST</pubDate>
+    </item>
+    <item>
+      <title>Theme Title: View over the town</title>
+      <link>http://kuler.adobe.com/index.cfm#themeID/1637621</link>
+      <guid>http://kuler.adobe.com/index.cfm#themeID/1637621</guid>
+      <enclosure xmlns="http://www.solitude.dk/syndication/enclosures/">
+        <title>View over the town</title>
+        <link type="image/png" length="1">
+          <url>http://kuler-api.adobe.com/kuler/themeImages/theme_1637621.png</url>
+        </link>
+      </enclosure>
+      <description>
+        &lt;img src="http://kuler-api.adobe.com/kuler/themeImages/theme_1637621.png" /&gt;&lt;br /&gt;
+        Artist: mariagroenlund&lt;br /&gt;ThemeID: 1637621&lt;br /&gt;Posted: 11/17/2011&lt;br /&gt;
+        Hex: FF5335, B29C85, 306E73, 3B424C, 1D181F
+      </description>
+      <kuler:themeItem>
+        <kuler:themeID>1637621</kuler:themeID>
+        <kuler:themeTitle>View over the town</kuler:themeTitle>
+        <kuler:themeImage>http://kuler-api.adobe.com/kuler/themeImages/theme_1637621.png</kuler:themeImage>
+        <kuler:themeAuthor>
+          <kuler:authorID>117768</kuler:authorID>
+          <kuler:authorLabel>mariagroenlund</kuler:authorLabel>
+        </kuler:themeAuthor>
+        <kuler:themeTags/>
+        <kuler:themeRating>4</kuler:themeRating>
+        <kuler:themeDownloadCount>1906</kuler:themeDownloadCount>
+        <kuler:themeCreatedAt>20111117</kuler:themeCreatedAt>
+        <kuler:themeEditedAt>20111117</kuler:themeEditedAt>
+        <kuler:themeSwatches>
+          <kuler:swatch>
+            <kuler:swatchHexColor>FF5335</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>1.0</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.324633</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.206316</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>0</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>B29C85</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.7</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.610016</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.521841</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>1</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>306E73</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.188235</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.431373</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.45098</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>2</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>3B424C</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.229412</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.257648</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.3</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>3</kuler:swatchIndex>
+          </kuler:swatch>
+          <kuler:swatch>
+            <kuler:swatchHexColor>1D181F</kuler:swatchHexColor>
+            <kuler:swatchColorMode>rgb</kuler:swatchColorMode>
+            <kuler:swatchChannel1>0.113725</kuler:swatchChannel1>
+            <kuler:swatchChannel2>0.094118</kuler:swatchChannel2>
+            <kuler:swatchChannel3>0.121569</kuler:swatchChannel3>
+            <kuler:swatchChannel4>0.0</kuler:swatchChannel4>
+            <kuler:swatchIndex>4</kuler:swatchIndex>
+          </kuler:swatch>
+        </kuler:themeSwatches>
+      </kuler:themeItem>
+      <pubDate>Sun, 10 Feb 2013 06:15:38 PST</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/test/fixtures/single_random_result.xml
+++ b/test/fixtures/single_random_result.xml
@@ -3,8 +3,7 @@
   <channel>
     <title>kuler popular themes</title>
     <link>http://kuler.adobe.com/</link>
-    <description>most popular themes on kuler (1 to 1 of
-    328331)</description>
+    <description>most popular themes on kuler (1 to 1 of 328331)</description>
     <language>en-us</language>
     <pubDate>Sun, 28 Mar 2010 19:00:58 PST</pubDate>
     <lastBuildDate>Sun, 28 Mar 2010 19:00:58 PST</lastBuildDate>
@@ -20,11 +19,9 @@
       <link>http://kuler.adobe.com/index.cfm#themeID/15325</link>
       <guid>http://kuler.adobe.com/index.cfm#themeID/15325</guid>
       <enclosure xmlns="http://www.solitude.dk/syndication/enclosures/">
-
         <title>sandy stone beach ocean diver</title>
         <link length="1" type="image/png">
-          <url>
-          http://kuler-api.adobe.com/kuler/themeImages/theme_15325.png</url>
+          <url>http://kuler-api.adobe.com/kuler/themeImages/theme_15325.png</url>
         </link>
       </enclosure>
       <description>&lt;img
@@ -36,14 +33,12 @@
       <kuler:themeItem>
         <kuler:themeID>15325</kuler:themeID>
         <kuler:themeTitle>sandy stone beach ocean diver</kuler:themeTitle>
-        <kuler:themeImage>
-        http://kuler-api.adobe.com/kuler/themeImages/theme_15325.png</kuler:themeImage>
+        <kuler:themeImage>http://kuler-api.adobe.com/kuler/themeImages/theme_15325.png</kuler:themeImage>
         <kuler:themeAuthor>
           <kuler:authorID>17923</kuler:authorID>
           <kuler:authorLabel>ps</kuler:authorLabel>
         </kuler:themeAuthor>
-        <kuler:themeTags>beach, diver, ocean, sandy,
-        stone</kuler:themeTags>
+        <kuler:themeTags>beach, diver, ocean, sandy, stone</kuler:themeTags>
         <kuler:themeRating>4</kuler:themeRating>
         <kuler:themeDownloadCount>20476</kuler:themeDownloadCount>
         <kuler:themeCreatedAt>20070118</kuler:themeCreatedAt>

--- a/test/test_kuler.rb
+++ b/test/test_kuler.rb
@@ -35,16 +35,23 @@ class TestKuler < Test::Unit::TestCase
   ### feed url generation
 
   def test_url_builder
-    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=20&key=#{API_KEY}&listType=recent"
+    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=20&key=#{API_KEY}&listType=recent&startIndex=0"
     actual = @kuler.build_url
 
     assert_equal expected, actual, "feed url incorrectly generated"
   end
 
   def test_url_builder_with_options
-    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=100&key=#{API_KEY}&listType=random"
+    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=100&key=#{API_KEY}&listType=random&startIndex=0"
 
     actual = @kuler.build_url(:type => :random, :limit => 100)
+    assert_equal expected, actual
+  end
+
+  def test_url_builder_with_offset
+    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=20&key=#{API_KEY}&listType=recent&startIndex=3"
+
+    actual = @kuler.build_url(:offset => 3)
     assert_equal expected, actual
   end
 

--- a/test/test_kuler.rb
+++ b/test/test_kuler.rb
@@ -101,5 +101,8 @@ class TestKuler < Test::Unit::TestCase
     end
 
     assert_equal options[:limit], themes.size, 'incorrect number of themes'
+
+    expected_theme_ids = [2216979, 1974489, 1994456, 2247332, 1637621]
+    assert_equal expected_theme_ids, themes.map{|t| t.theme_id }
   end
 end

--- a/test/test_kuler.rb
+++ b/test/test_kuler.rb
@@ -26,14 +26,14 @@ class TestKuler < Test::Unit::TestCase
   ### feed url generation
 
   def test_url_builder
-    expected = "http://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=20&key=#{API_KEY}&listType=recent"
+    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=20&key=#{API_KEY}&listType=recent"
     actual = @kuler.build_url
 
     assert_equal expected, actual, "feed url incorrectly generated"
   end
 
   def test_url_builder_with_options
-    expected = "http://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=100&key=#{API_KEY}&listType=random"
+    expected = "https://kuler-api.adobe.com/rss/get.cfm?itemsPerPage=100&key=#{API_KEY}&listType=random"
 
     actual = @kuler.build_url( :type => :random, :limit => 100 )
     assert_equal expected, actual
@@ -49,19 +49,12 @@ class TestKuler < Test::Unit::TestCase
       @kuler.build_url :type => :recent
     end
 
-    # invalid counts
-    assert_raise ArgumentError do
-      @kuler.build_url :limit => 0
-    end
-
-    assert_raise ArgumentError do
-      @kuler.build_url :limit => 101
-    end
-
     assert_nothing_raised do
+      @kuler.build_url :limit => 0
       @kuler.build_url :limit => 1
       @kuler.build_url :limit => 50
       @kuler.build_url :limit => 100
+      @kuler.build_url :limit => 101
     end
 
   end

--- a/test/test_kuler.rb
+++ b/test/test_kuler.rb
@@ -1,5 +1,5 @@
 require "test/unit"
-require 'mocha'
+require 'mocha/setup'
 require 'pathname'
 
 require "kuler"

--- a/test/test_kuler_swatch.rb
+++ b/test/test_kuler_swatch.rb
@@ -1,5 +1,5 @@
 require "test/unit"
-require 'mocha'
+require 'mocha/setup'
 require 'pathname'
 
 require "kuler"

--- a/test/test_kuler_theme.rb
+++ b/test/test_kuler_theme.rb
@@ -42,5 +42,10 @@ class TestKulerTheme < Test::Unit::TestCase
     assert_equal expected, @theme.hex_codes
   end
 
+  def test_tags
+    expected = %w[ beach diver ocean sandy stone ]
+    assert_equal expected, @theme.tags
+  end
+
 
 end

--- a/test/test_kuler_theme.rb
+++ b/test/test_kuler_theme.rb
@@ -4,12 +4,12 @@ require 'pathname'
 require "kuler"
 
 class TestKulerTheme < Test::Unit::TestCase
-  FIXTURES = Pathname.new( File.dirname(__FILE__) ).expand_path + "fixtures"
+  FIXTURES = Pathname.new(File.dirname(__FILE__)).expand_path.join("fixtures")
 
   def setup
-    xml = FIXTURES + "single_random_result.xml"
-    nodes = Nokogiri::XML( xml.read ).at( "//kuler:themeItem" )
-    @theme = Kuler::Theme.new( nodes )
+    xml = FIXTURES.join("single_random_result.xml")
+    nodes = Nokogiri::XML(xml.read).at("//kuler:themeItem")
+    @theme = Kuler::Theme.new(nodes)
   end
 
   ########################################################################
@@ -18,7 +18,7 @@ class TestKulerTheme < Test::Unit::TestCase
   def test_create
     assert_equal 15325, @theme.theme_id
     assert_equal "sandy stone beach ocean diver", @theme.title
-    assert_equal %w( beach diver ocean sandy stone ), @theme.tags
+    assert_equal %w[ beach diver ocean sandy stone ], @theme.tags
     assert_equal 4, @theme.rating
 
     assert_equal "ps", @theme.author_name
@@ -31,14 +31,7 @@ class TestKulerTheme < Test::Unit::TestCase
   end
 
   def test_hex_codes
-    expected = [
-      "#e6e2af",
-      "#a7a37e",
-      "#efecca",
-      "#046380",
-      "#002f2f"
-    ]
-
+    expected = %w[ #e6e2af #a7a37e #efecca #046380 #002f2f ]
     assert_equal expected, @theme.hex_codes
   end
 
@@ -46,6 +39,4 @@ class TestKulerTheme < Test::Unit::TestCase
     expected = %w[ beach diver ocean sandy stone ]
     assert_equal expected, @theme.tags
   end
-
-
 end


### PR DESCRIPTION
I've taken the liberty to provide an advanced interface to the Kuler API.

Instead of just fetching a single, random color theme, one might now use `kuler.fetch_theme` and use the `kuler.build_url` options to search for more themes.

I stuck to the old Ruby 1.8 syntax, though I only did test it against current MRI 1.9.3.
